### PR TITLE
Update defaults.go

### DIFF
--- a/internal/presets/defaults.go
+++ b/internal/presets/defaults.go
@@ -3,53 +3,109 @@ package presets
 var DefaultTLDPresets = map[string][]string{
 	"popular": {
 		"com", "net", "org", "co", "io", "me", "dev", "app", "ai",
+		"xyz", "online", "site", "info", "blog",	
 	},
 	"tech": {
 		"io", "dev", "app", "ai", "cloud", "tech", "software", "systems",
+		"digital", "code", "codes", "data", "network", "security", "tools",
+		"technology", "games",
 	},
 	"personal": {
 		"me", "name", "bio", "life", "xyz", "site", "blog",
+		"portfolio", "photos", "photo", "photography", "pics", "pictures",
 	},
 	"startup": {
 		"com", "io", "ai", "co", "app", "tech", "cloud", "app", "ly",
+		"vc", "solutions", "ventures", "fund", "agency",
 	},
 	"cheap": {
 		"xyz", "icu", "site", "online", "space", "fun", "store", "shop", "click",
+		"bond", "pw",'
 	},
 	"luxury": {
 		"luxury", "vip", "rich", "club", "jewelry", "gold",
+		"yachts", "estate", "diamonds", "boutique",
 	},
 	"finance": {
 		"finance", "money", "investments", "capital", "fund", "loans",
+		"bank", "cash", "credit", "exchange",
 	},
 	"design": {
 		"design", "graphics", "studio", "art", "gallery", "ink",
+		"style", "photos", "fashion",
 	},
 	"geek": {
 		"dev", "sh", "lol", "wtf", "zip", "ninja", "tech", "codes",
+		"geek", "foo", "wiki",
 	},
 	"experimental": {
 		"zip", "mov", "phd", "prof", "esq", "boo",
 	},
 	"geo": {
 		"us", "uk", "ca", "de", "fr", "in", "au", "eu", "asia", "co.uk",
+		"nyc", "london", "berlin", "paris", "tokyo", "africa",
 	},
 	"security": {
-		"security", "safe", "trust", "protection",
+		"security", "safe", "trust", "protection", "guard",
 	},
 	"creative": {
-		"art", "design", "ink", "gallery", "photo", "photography", "pics", "pictures", "studio", "style", "film", "show", "actor", "audio", "video", "dance", "music",
+		"art", "design", "ink", "gallery", "photo", "photography", "pics", "pictures", "studio", "style", 
+		"film", "show", "actor", "audio", "video", "dance", "music", "productions", "media",
 	},
 	"business": {
-		"com", "co", "biz", "ltd", "llc", "inc", "company", "global", "international", "solutions", "enterprises", "group", "holdings", "agency", "network", "ventures", "partners",
+		"com", "co", "biz", "ltd", "llc", "inc", "company", "global", "international", "solutions", "enterprises", 
+		"group", "holdings", "agency", "network", "ventures", "partners", "firm", "consulting", "services",
 	},
 	"food": {
-		"cafe", "bar", "restaurant", "pub", "menu", "eat", "pizza", "organic", "recipes", "cooking", "kitchen", "catering", "delivery",
+		"cafe", "bar", "restaurant", "pub", "menu", "eat", "pizza", "organic", "recipes", 
+		"cooking", "kitchen", "catering", "delivery", "food", "wine", "beer",
 	},
 	"social": {
-		"social", "community", "chat", "forum", "fans", "live", "lol", "wtf", "sucks", "fyi", "network", "group", "online", "link",
+		"social", "community", "chat", "forum", "fans", "live", "lol", "wtf", "sucks", 
+		"fyi", "network", "group", "online", "link", "connect", "events",
 	},
 	"shopping": {
-		"shop", "store", "buy", "sale", "market", "shopping", "boutique", "deals", "forsale", "promo", "gift", "blackfriday",
+		"shop", "store", "buy", "sale", "market", "shopping", "boutique", "deals", 
+		"forsale", "promo", "gift", "blackfriday", "auction", "bargains",
+	},
+	"education": {
+		"edu", "academy", "college", "university", "school", "courses",
+		"training", "degree", "education", "institute", "study",
+	},
+	"health_wellness": {
+		"health", "clinic", "care", "fitness", "diet", "yoga", "therapy",
+		"hospital", "medical", "pharmacy", "healthcare",
+	},
+	"travel_tourism": {
+		"travel", "tours", "vacations", "voyage", "flights", "hotel",
+		"guide", "explore", "camp", "cruises", "rentals",
+	},
+	"real_estate": {
+		"realestate", "property", "estate", "homes", "house", "apartments",
+		"rent", "lease", "mortgage",
+	},
+	"automotive": {
+		"auto", "cars", "tires", "parts", "repair", "dealer", "garage",
+		"motorcycles",
+	},
+	"sports": {
+		"sport", "team", "club", "fitness", "football", "soccer", "golf",
+		"tennis", "bike", "ski", "bet",
+	},
+	"legal": {
+		"law", "legal", "attorney", "lawyer", "claims", "esq",
+	},
+	"crafts_hobbies": {
+		"art", "craft", "diy", "garden", "fishing", "cooking", "book",
+	},
+	"news_information": {
+		"news", "report", "press", "info", "today", "buzz", "fyi",
+	},
+	"services": {
+		"services", "solutions", "support", "delivery", "cleaning", "plumbing",
+		"taxi", "coach",
+	},
+	"non_profit_community": {
+		"ngo", "foundation", "charity", "community", "gives",
 	},
 }

--- a/internal/presets/defaults.go
+++ b/internal/presets/defaults.go
@@ -2,8 +2,7 @@ package presets
 
 var DefaultTLDPresets = map[string][]string{
 	"popular": {
-		"com", "net", "org", "co", "io", "me", "dev", "app", "ai",
-		"xyz", "online", "site", "info", "blog",	
+		"com", "net", "org", "co", "io", "me", "dev", "app", "ai",	
 	},
 	"tech": {
 		"io", "dev", "app", "ai", "cloud", "tech", "software", "systems",
@@ -20,7 +19,7 @@ var DefaultTLDPresets = map[string][]string{
 	},
 	"cheap": {
 		"xyz", "icu", "site", "online", "space", "fun", "store", "shop", "click",
-		"bond", "pw",'
+		"bond", "pw", "xyz", "online", "site", "info", "blog",
 	},
 	"luxury": {
 		"luxury", "vip", "rich", "club", "jewelry", "gold",


### PR DESCRIPTION
Key changes:
- **New Categories:** Added specialized categories such as `education`, `health_wellness`, `travel_tourism`, `real_estate`, `automotive`, `sports`, `legal`, `crafts_hobbies`, `news_information`, `services`, and `non_profit_community`.
- **Expanded Existing Categories:** Incorporated numerous additional TLDs into existing categories like `popular`, `tech`, `personal`, `finance`, `design`, `geek`, `business`, `food`, `social`, and `shopping`.