### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/brandonyoungdev/tldx/security/code-scanning/1](https://github.com/brandonyoungdev/tldx/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily involves checking out the code, setting up Go, installing dependencies, building, and running tests. These tasks only require `contents: read` permission. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
